### PR TITLE
Fix for New Firefox releases

### DIFF
--- a/bci/browser/binary/binary.py
+++ b/bci/browser/binary/binary.py
@@ -102,8 +102,21 @@ class Binary:
     def is_available_online(self):
         return self.state.has_online_binary()
 
-    @abstractmethod
     def download_binary(self):
+        if self.is_available_locally():
+            logger.debug(f'Binary for {self.state} was already downloaded ({self.get_bin_path()})')
+        else:
+            binary_urls = self.state.get_online_binary_urls()
+            binary_dst_folder = os.path.dirname(self.get_potential_bin_path())
+            util.download_and_extract(binary_urls, binary_dst_folder)
+        self.configure_binary()
+
+    @abstractmethod
+    def configure_binary(self):
+        """
+        Configures the browser binary.
+        This method is idempotent.
+        """
         pass
 
     def is_built(self):

--- a/bci/database/mongo/binary_cache.py
+++ b/bci/database/mongo/binary_cache.py
@@ -136,6 +136,10 @@ class BinaryCache:
                 logger.debug(f'Stored binary in {elapsed_time:.2f}s')
 
     @staticmethod
+    def remove_binary_files(state: State) -> None:
+        BinaryCache.__remove_revision_binary_files(state.type, state.index)
+
+    @staticmethod
     def __count_cached_binaries(state_type: Optional[str] = None) -> int:
         """
         Counts the number of cached binaries in the database.

--- a/bci/version_control/states/revisions/chromium.py
+++ b/bci/version_control/states/revisions/chromium.py
@@ -22,16 +22,16 @@ class ChromiumRevision(BaseRevision):
         if cached_binary_available_online is not None:
             return cached_binary_available_online
         url = f'https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F{self._revision_nb}%2Fchrome-linux.zip'
-        req = requests.get(url)
-        has_binary_online = req.status_code == 200
+        response = requests.get(url, stream=True)
+        has_binary_online = response.status_code == 200
         MongoDB().store_binary_availability_online_cache('chromium', self, has_binary_online)
         return has_binary_online
 
-    def get_online_binary_url(self):
-        return (
+    def get_online_binary_urls(self) -> list[str]:
+        return [(
             'https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/%s%%2F%s%%2Fchrome-%s.zip?alt=media'
             % ('Linux_x64', self._revision_nb, 'linux')
-        )
+        )]
 
     def _fetch_missing_data(self) -> None:
         """

--- a/bci/version_control/states/revisions/firefox.py
+++ b/bci/version_control/states/revisions/firefox.py
@@ -26,14 +26,14 @@ class FirefoxRevision(BaseRevision):
     def has_online_binary(self) -> bool:
         return RevisionCache.firefox_has_binary_for(revision_nb=self.revision_nb, revision_id=self._revision_id)
 
-    def get_online_binary_url(self) -> str:
+    def get_online_binary_urls(self) -> list[str]:
         result = RevisionCache.firefox_get_binary_info(self._revision_id)
         if result is None:
             raise AttributeError(f"Could not find binary url for '{self._revision_id}")
         binary_base_url = result['files_url']
         app_version = result['app_version']
         binary_url = f'{binary_base_url}firefox-{app_version}.en-US.linux-x86_64.tar.bz2'
-        return binary_url
+        return [binary_url]
 
     def get_previous_and_next_state_with_binary(self) -> tuple[State, State]:
         previous_revision_nb, next_revision_nb = RevisionCache.firefox_get_previous_and_next_revision_nb_with_binary(

--- a/bci/version_control/states/state.py
+++ b/bci/version_control/states/state.py
@@ -139,7 +139,10 @@ class State:
         pass
 
     @abstractmethod
-    def get_online_binary_url(self) -> str:
+    def get_online_binary_urls(self) -> list[str]:
+        """
+        Returns a list of URLs where the associated binary can potentially be downloaded from.
+        """
         pass
 
     def has_available_binary(self) -> bool:

--- a/bci/version_control/states/versions/chromium.py
+++ b/bci/version_control/states/versions/chromium.py
@@ -30,11 +30,11 @@ class ChromiumVersion(BaseVersion):
         MongoDB().store_binary_availability_online_cache('chromium', self, has_binary_online)
         return has_binary_online
 
-    def get_online_binary_url(self):
-        return (
+    def get_online_binary_urls(self) -> list[str]:
+        return [(
             'https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/%s%%2F%s%%2Fchrome-%s.zip?alt=media'
             % ('Linux_x64', self._revision_nb, 'linux')
-        )
+        )]
 
     def convert_to_revision(self) -> ChromiumRevision:
         return ChromiumRevision(revision_nb=self._revision_nb)

--- a/bci/version_control/states/versions/firefox.py
+++ b/bci/version_control/states/versions/firefox.py
@@ -1,10 +1,9 @@
-from bci.version_control.repository.online.firefox import get_release_revision_number, get_release_revision_id
+from bci.version_control.repository.online.firefox import get_release_revision_id, get_release_revision_number
 from bci.version_control.states.revisions.firefox import FirefoxRevision
 from bci.version_control.states.versions.base import BaseVersion
 
 
 class FirefoxVersion(BaseVersion):
-
     def __init__(self, major_version: int):
         super().__init__(major_version)
 
@@ -21,8 +20,11 @@ class FirefoxVersion(BaseVersion):
     def has_online_binary(self) -> bool:
         return True
 
-    def get_online_binary_url(self) -> str:
-        return f'https://ftp.mozilla.org/pub/firefox/releases/{self.major_version}.0/linux-x86_64/en-US/firefox-{self.major_version}.0.tar.bz2'
+    def get_online_binary_urls(self) -> list[str]:
+        return [
+            f'https://ftp.mozilla.org/pub/firefox/releases/{self.major_version}.0/linux-x86_64/en-US/firefox-{self.major_version}.0.tar.bz2',
+            f'https://ftp.mozilla.org/pub/firefox/releases/{self.major_version}.0/linux-x86_64/en-US/firefox-{self.major_version}.0.tar.xz'
+        ]
 
     def convert_to_revision(self) -> FirefoxRevision:
         return FirefoxRevision(revision_nb=self._revision_nb)


### PR DESCRIPTION
Fix for New Firefox releases that are provided in tar.xz instead of tar.bz2 #44

Firefox releases from v135 onwards use tar.xz instead of tar.bz2. 
Updated the extraction logic to detect the correct archive format based on version and extract it accordingly.